### PR TITLE
fix(sdk): Add streaming headers to streamAssistantResponse requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.15.1] - 2025-10-14
+
+### Fixed
+- **Streaming Headers**: Fixed `streamAssistantResponse` requests to include proper HTTP headers
+  - Added `Accept: text/event-stream` header to properly request streaming responses
+  - Added `Content-Type: application/json` header for correct request formatting
+  - Resolves "Unsupported Media Type" errors in streaming API calls
+
 ## [0.15.0] - 2025-10-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Note: The PostHog helper is currently internal and not exported from the package
     - `message`: string — required
     - `language`: `"en" | "pt"` — optional, defaults to `"en"`
   - Returns: `AsyncGenerator<string, void, unknown>` — async generator that yields streaming response chunks
+  - Note: Automatically includes proper streaming headers (`Accept: text/event-stream`) for API compatibility
 
 ### PostHog Analytics Helper
 

--- a/__tests__/sdk.test.ts
+++ b/__tests__/sdk.test.ts
@@ -389,7 +389,11 @@ describe("ContentaGenSDK.streamAssistantResponse", () => {
 		expect(fetchMock).toHaveBeenCalledWith(
 			expect.stringContaining("/trpc/sdk.streamAssistantResponse"),
 			{
-				headers: { "sdk-api-key": apiKey },
+				headers: {
+					"sdk-api-key": apiKey,
+					"Accept": "text/event-stream",
+					"Content-Type": "application/json"
+				},
 			},
 		);
 	});
@@ -628,6 +632,8 @@ describe("ContentaGenSDK locale functionality", () => {
 				headers: {
 					"sdk-api-key": apiKey,
 					"x-locale": "pt-BR",
+					"Accept": "text/event-stream",
+					"Content-Type": "application/json"
 				},
 			},
 		);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@contentagen/sdk",
-	"version": "0.15.0",
+	"version": "0.15.1",
 	"private": false,
 	"type": "module",
 	"description": "Official TypeScript SDK to interact with the ContentaGen API. Provides lightweight client methods for listing and retrieving content, automatic input validation, date parsing, and robust error handling.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,11 +262,17 @@ export class ContentaGenSDK {
 	): AsyncGenerator<string, void, unknown> {
 		try {
 			const validatedParams = StreamAssistantResponseInputSchema.parse(params);
-			const url = new URL(`${this.trpcUrl}/sdk.${TRPC_ENDPOINTS.streamAssistantResponse}`);
+			const url = new URL(
+				`${this.trpcUrl}/sdk.${TRPC_ENDPOINTS.streamAssistantResponse}`,
+			);
 			url.searchParams.set("input", SuperJSON.stringify(validatedParams));
 
 			const response = await fetch(url.toString(), {
-				headers: this.getHeaders(),
+				headers: {
+					...this.getHeaders(),
+					Accept: "text/event-stream",
+					"Content-Type": "application/json",
+				},
 			});
 
 			if (!response.ok) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses now include proper headers to prevent “Unsupported Media Type” errors and ensure compatibility.

* **Documentation**
  * Clarified that streaming automatically sets the correct headers for event-stream responses; no API changes.

* **Tests**
  * Updated streaming tests to expect the new headers in both standard and locale-aware flows.

* **Chores**
  * Bumped version to 0.15.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->