### PR TITLE
refactor: Refactor streamAssistantResponse method implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.15.3] - 2025-10-14
+
+### Changed
+- **streamAssistantResponse Method**: Refactored from streaming async generator to simple query method
+  - Changed from `AsyncGenerator<string>` to standard `Promise<T>` return type
+  - Removed internal streaming logic and now uses the `_query` method
+  - Improved consistency with other SDK methods and simplified implementation
+  - Updated method signature to return validated response data
+
 ## [0.15.2] - 2025-10-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Official TypeScript SDK for interacting with the ContentaGen API.
 - Locale support via `x-locale` header for internationalization
 - Agents can be used as authors (author info is derived from the agent config)
 - New procedures: `getAuthorByAgentId`, `getRelatedSlugs`, `getContentImage`, `streamAssistantResponse`
-- Streaming support for real-time AI assistant responses with language selection
+- AI assistant response support with language selection
 - Selected schemas and types exported for advanced usage
 
 ## Installation
@@ -68,13 +68,12 @@ async function example() {
 	const image = await sdk.getContentImage({ contentId: post.id });
 	console.log("Post image:", image?.contentType, image?.data.length);
 
-	// Stream assistant response
-	for await (const chunk of sdk.streamAssistantResponse({
+	// Get assistant response
+	const response = await sdk.streamAssistantResponse({
 		message: "Hello, assistant!",
 		language: "en" // Optional: "en" or "pt", defaults to "en"
-	})) {
-		process.stdout.write(chunk);
-	}
+	});
+	console.log(response);
 }
 ```
 
@@ -129,9 +128,8 @@ Note: The PostHog helper is currently internal and not exported from the package
   - params (validated by `StreamAssistantResponseInputSchema`):
     - `message`: string — required
     - `language`: `"en" | "pt"` — optional, defaults to `"en"`
-  - Returns: `AsyncGenerator<string, void, unknown>` — async generator that yields streaming response chunks
-  - Note: Uses simplified chunk decoding for improved reliability and compatibility across different environments
-  - Note: Automatically includes proper streaming headers (`Accept: application/json`) for API compatibility
+  - Returns: `Promise<StreamAssistantResponseInputSchema>` — standard promise returning validated response data
+  - Note: Uses the `_query` method for consistency with other SDK methods
 
 ### PostHog Analytics Helper
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@contentagen/sdk",
-	"version": "0.15.2",
+	"version": "0.15.3",
 	"private": false,
 	"type": "module",
 	"description": "Official TypeScript SDK to interact with the ContentaGen API. Provides lightweight client methods for listing and retrieving content, automatic input validation, date parsing, and robust error handling.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Assistant response API now returns a single, complete result via a promise instead of streaming chunks.
- Documentation
  - Updated README and examples to show the new non-streaming usage pattern and return type.
- Chores
  - Bumped version to 0.15.3.
  - Added changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->